### PR TITLE
[codex] Integrate xip DNS and refresh deployment UX

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.git
+.idea
+.DS_Store
+Dockerfile.runtime
+unicorn.pid
+db/*.sqlite3
+db/*.sqlite3-*

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,12 @@
+# Web service
+MYURLS_BIND=127.0.0.1
+MYURLS_PORT=9292
+
+# Optional xip DNS service
+XIP_WEB_HOST=xip.example.com
+DNS_BIND=0.0.0.0
+DNS_PORT=8053
+DNS_ZONE=xip.example.com
+DNS_DEFAULT_IP=203.0.113.10
+DNS_NAMESERVER=short.example.com
+DNS_TTL=300

--- a/README.md
+++ b/README.md
@@ -1,17 +1,264 @@
 # Myurls
 
-URL shortener
+A small self-hosted URL shortener with an optional nip.io-style DNS service.
 
-## Deploy your own instance using Docker
-On the server/machine you want to host this, you'll first need a machine withdocker and docker-compose installed, then grap this source using git:
+Myurls can run two services from the same Docker image:
 
-```bash
-git clone git://github.com/fatjyc/myurls.git
+- **Web:** shorten URLs and redirect short links.
+- **xip DNS (optional):** resolve an IPv4 address embedded in a hostname.
+
+```text
+127.0.0.1.xip.example.com    -> 127.0.0.1
+127-0-0-1.xip.example.com    -> 127.0.0.1
+app.10-0-0-8.xip.example.com -> 10.0.0.8
 ```
 
-Go into the project directory, then initialization the database and run the service
+## Requirements
+
+- A Linux server with a public IPv4 address
+- Docker Engine with the `docker compose` command
+- A domain name pointed at the server
+- Nginx or another reverse proxy for HTTPS
+- TCP and UDP port 53 open if the optional xip DNS service is enabled
+
+## Quick start: URL shortener only
+
+Clone the repository and create the local configuration:
+
+```bash
+git clone https://github.com/fatjyc/myurls.git
+cd myurls
+cp .env.example .env
+```
+
+Review `.env` if you need to change the local bind address or port. Replace
+`short.example.com` in the reverse-proxy examples with your real domain.
+
+Build the image, create the database tables, and start the web service:
 
 ```bash
 ./init_db.sh
-docker-compose up -d
+docker compose up -d myurls
 ```
+
+The application is now available locally on the server at
+`http://127.0.0.1:9292`.
+
+Check its status:
+
+```bash
+docker compose ps
+curl -I -H 'Host: short.example.com' http://127.0.0.1:9292/
+```
+
+## Reverse proxy and HTTPS
+
+The container only binds the web service to localhost by default. Put Nginx,
+Caddy, or another reverse proxy in front of it.
+
+Minimal Nginx configuration:
+
+```nginx
+server {
+    listen 80;
+    listen [::]:80;
+    server_name short.example.com;
+
+    location / {
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_pass http://127.0.0.1:9292;
+    }
+}
+```
+
+After enabling the site, issue a certificate. For example, with Certbot:
+
+```bash
+sudo nginx -t
+sudo systemctl reload nginx
+sudo certbot --nginx -d short.example.com
+```
+
+## Enable xip DNS
+
+The DNS service is optional and is placed behind the Compose `xip` profile.
+Configure it in `.env`:
+
+```dotenv
+XIP_WEB_HOST=xip.example.com
+DNS_ZONE=xip.example.com
+DNS_DEFAULT_IP=203.0.113.10
+DNS_NAMESERVER=short.example.com
+```
+
+- `DNS_ZONE` is the delegated hostname suffix.
+- `DNS_DEFAULT_IP` is the server's public IPv4 address and is returned for the
+  zone root, such as `xip.example.com`.
+- `DNS_NAMESERVER` must resolve to the server running this DNS service.
+- `XIP_WEB_HOST` makes the web application show the built-in xip documentation
+  page when that hostname is opened in a browser.
+
+Start both services:
+
+```bash
+docker compose --profile xip up -d --build
+```
+
+The DNS container listens on both TCP and UDP port 53. Ensure those ports are
+open in the operating-system firewall and cloud-provider firewall.
+
+### Delegate the DNS zone
+
+At the DNS provider for `example.com`, add an NS record:
+
+```text
+Type:    NS
+Name:    xip
+Target:  short.example.com
+```
+
+Do not add a wildcard A record such as `*.xip.example.com`. A wildcard A record
+would return one fixed address and prevent queries from reaching the dynamic
+DNS service.
+
+Once the delegation has propagated, verify both supported formats:
+
+```bash
+dig 127.0.0.1.xip.example.com A +short
+dig 127-0-0-1.xip.example.com A +short
+```
+
+Both commands should return:
+
+```text
+127.0.0.1
+```
+
+To serve the xip documentation page, add `xip.example.com` to the reverse proxy
+and point it to the same web container:
+
+```nginx
+server {
+    listen 80;
+    listen [::]:80;
+    server_name xip.example.com;
+
+    location / {
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_pass http://127.0.0.1:9292;
+    }
+}
+```
+
+Then issue its HTTPS certificate:
+
+```bash
+sudo certbot --nginx -d xip.example.com
+```
+
+## Configuration
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `MYURLS_BIND` | `127.0.0.1` | Host address used for the web port binding. |
+| `MYURLS_PORT` | `9292` | Host port used for the web service. |
+| `XIP_WEB_HOST` | `xip.1gb.xyz` | Hostname that renders the xip documentation page. |
+| `DNS_BIND` | `0.0.0.0` | Address used for TCP/UDP port 53 bindings. |
+| `DNS_PORT` | `8053` | DNS port inside the container. |
+| `DNS_ZONE` | `xip.1gb.xyz` | Authoritative DNS suffix. |
+| `DNS_DEFAULT_IP` | `127.0.0.1` | A record returned for the DNS zone root. |
+| `DNS_NAMESERVER` | `localhost` | Nameserver hostname returned by the DNS service. |
+| `DNS_TTL` | `300` | DNS response TTL in seconds. |
+
+## Database and backups
+
+Production data is stored in `db/production.sqlite3` and mounted into the web
+container. `init_db.sh` runs migrations without deleting existing data.
+
+Back up the database before upgrades:
+
+```bash
+cp db/production.sqlite3 "db/production.sqlite3.$(date +%Y%m%d-%H%M%S).bak"
+```
+
+Apply new migrations and restart:
+
+```bash
+./init_db.sh
+docker compose up -d --build myurls
+```
+
+## Operations
+
+```bash
+# Follow web logs
+docker compose logs -f myurls
+
+# Follow DNS logs
+docker compose --profile xip logs -f xip
+
+# Restart the web service
+docker compose restart myurls
+
+# Stop everything, preserving the database
+docker compose --profile xip down
+```
+
+## Tests
+
+Run the test suite inside the production Ruby environment:
+
+```bash
+docker compose build myurls
+docker compose run --rm -e APP_ENV=test -e RACK_ENV=test myurls bundle exec rake test
+```
+
+## Troubleshooting
+
+### The website returns 502
+
+Check that the container is running and port 9292 is listening:
+
+```bash
+docker compose ps
+docker compose logs --tail=100 myurls
+curl -I http://127.0.0.1:9292/
+```
+
+### DNS returns the server IP for every hostname
+
+Remove any wildcard A record for the delegated xip zone. Only the NS delegation
+should exist at the parent DNS provider.
+
+### DNS works with `dig @SERVER_IP` but not normally
+
+Confirm the NS delegation, TCP/UDP port 53 firewall rules, and public address:
+
+```bash
+dig xip.example.com NS
+dig @203.0.113.10 127-0-0-1.xip.example.com A +short
+```
+
+### Queries return addresses in `198.18.0.0/15`
+
+Some proxy applications use that range for fake-IP DNS. Add the xip zone to the
+proxy's real-IP/bypass list and route the zone directly.
+
+### Old Docker reports `can't create Thread: Operation not permitted`
+
+Upgrade Docker and the host operating system. As a temporary workaround on a
+trusted server, add the following to the affected service:
+
+```yaml
+security_opt:
+  - seccomp:unconfined
+```
+
+This disables the container's seccomp filter, so upgrading Docker is the safer
+long-term solution.

--- a/bin/xip-dns
+++ b/bin/xip-dns
@@ -1,0 +1,13 @@
+#!/usr/bin/env ruby
+# encoding: UTF-8
+
+require File.expand_path('../lib/xip_dns', __dir__)
+
+Myurls::XipDns.run(
+  host: ENV.fetch('DNS_HOST', '0.0.0.0'),
+  port: Integer(ENV.fetch('DNS_PORT', '8053')),
+  zone: ENV.fetch('DNS_ZONE', 'xip.1gb.xyz'),
+  default_ip: ENV.fetch('DNS_DEFAULT_IP'),
+  nameserver: ENV.fetch('DNS_NAMESERVER', '1gb.xyz'),
+  ttl: Integer(ENV.fetch('DNS_TTL', '300'))
+)

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -14,6 +14,6 @@ require 'haml'
 require 'json'
 
 require File.join(File.dirname(__FILE__), '..', 'myurls')
-%w[utils urls].each do |lib|
+%w[utils urls xip_dns].each do |lib|
   require File.join(File.dirname(__FILE__), '..', 'lib', lib)
 end

--- a/deploy/nginx/xip.1gb.xyz.conf
+++ b/deploy/nginx/xip.1gb.xyz.conf
@@ -1,0 +1,10 @@
+server {
+    listen 80;
+    listen [::]:80;
+    server_name xip.1gb.xyz;
+
+    location / {
+        include proxy.conf;
+        proxy_pass http://127.0.0.1:9292;
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   myurls:
     build: .
@@ -7,17 +5,37 @@ services:
     restart: unless-stopped
     command: bundle exec unicorn -c config/unicorn.rb
     ports:
-      - "127.0.0.1:9292:9292"
+      - "${MYURLS_BIND:-127.0.0.1}:${MYURLS_PORT:-9292}:9292"
     volumes:
       - ./db:/app/db
     environment:
       - APP_ENV=production
       - RACK_ENV=production
+      - XIP_WEB_HOST=${XIP_WEB_HOST:-xip.1gb.xyz}
     healthcheck:
-      test: ["CMD", "nc", "-z", "localhost", "9292"]
+      test: ["CMD", "ruby", "-rsocket", "-e", "TCPSocket.new('127.0.0.1', 9292).close"]
       interval: 30s
       timeout: 10s
       retries: 3
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+  xip:
+    profiles: ["xip"]
+    image: jiong/myurls
+    restart: unless-stopped
+    command: bundle exec ruby bin/xip-dns
+    ports:
+      - "${DNS_BIND:-0.0.0.0}:53:${DNS_PORT:-8053}/tcp"
+      - "${DNS_BIND:-0.0.0.0}:53:${DNS_PORT:-8053}/udp"
+    environment:
+      - DNS_PORT=${DNS_PORT:-8053}
+      - DNS_ZONE=${DNS_ZONE:-xip.1gb.xyz}
+      - DNS_DEFAULT_IP=${DNS_DEFAULT_IP:-127.0.0.1}
+      - DNS_NAMESERVER=${DNS_NAMESERVER:-localhost}
+      - DNS_TTL=${DNS_TTL:-300}
     logging:
       driver: "json-file"
       options:

--- a/init_db.sh
+++ b/init_db.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 
-cur_dir=$(cd $(dirname "$0"); pwd)
+set -euo pipefail
 
-rm -fr "${cur_dir}"/db/production.sqlite3
+cur_dir=$(cd "$(dirname "$0")"; pwd)
+cd "$cur_dir"
 
-docker run --rm -v "${cur_dir}"/db:/app/db -e APP_ENV=production -w /app jiong/myurls bash -cx "bundle exec rake db:migrate"
+mkdir -p db
+docker compose build myurls
+docker compose run --rm myurls bundle exec rake db:migrate

--- a/lib/xip_dns.rb
+++ b/lib/xip_dns.rb
@@ -1,0 +1,161 @@
+# encoding: UTF-8
+
+require 'ipaddr'
+require 'socket'
+
+module Myurls
+  module XipDns
+    TYPE_A = 1
+    TYPE_NS = 2
+    TYPE_SOA = 6
+    CLASS_IN = 1
+
+    module_function
+
+    def extract_ipv4(name, zone)
+      labels = relative_labels(name, zone)
+      return if labels.nil? || labels.empty?
+
+      candidates = []
+      candidates << labels.last.tr('-', '.') if labels.last.match?(/\A\d+(?:-\d+){3}\z/)
+      candidates << labels.last(4).join('.') if labels.length >= 4
+
+      candidates.find { |candidate| valid_ipv4?(candidate) }
+    end
+
+    def answer(packet, zone:, default_ip:, nameserver:, ttl: 300)
+      return if packet.bytesize < 12
+
+      id, flags, question_count = packet.unpack('n3')
+      return if question_count.zero?
+
+      name, offset = decode_name(packet, 12)
+      return if offset + 4 > packet.bytesize
+
+      question_type, question_class = packet.byteslice(offset, 4).unpack('n2')
+      question = packet.byteslice(12, offset + 4 - 12)
+      records = records_for(
+        name,
+        question_type,
+        question_class,
+        zone: zone,
+        default_ip: default_ip,
+        nameserver: nameserver,
+        ttl: ttl
+      )
+
+      response_flags = 0x8400 | (flags & 0x0100)
+      [id, response_flags, 1, records.length, 0, 0].pack('n6') + question + records.join
+    rescue ArgumentError, IPAddr::InvalidAddressError
+      nil
+    end
+
+    def run(host: '0.0.0.0', port: 8053, zone:, default_ip:, nameserver:, ttl: 300)
+      udp = UDPSocket.new
+      udp.bind(host, port)
+      tcp = TCPServer.new(host, port)
+
+      udp_thread = Thread.new do
+        loop do
+          packet, sender = udp.recvfrom(4096)
+          response = answer(packet, zone: zone, default_ip: default_ip, nameserver: nameserver, ttl: ttl)
+          udp.send(response, 0, sender[3], sender[1]) if response
+        end
+      end
+
+      tcp_thread = Thread.new do
+        loop do
+          client = tcp.accept
+          Thread.new(client) do |connection|
+            length_data = connection.read(2)
+            next unless length_data&.bytesize == 2
+
+            packet = connection.read(length_data.unpack1('n'))
+            response = answer(packet, zone: zone, default_ip: default_ip, nameserver: nameserver, ttl: ttl)
+            connection.write([response.bytesize].pack('n') + response) if response
+          ensure
+            connection.close
+          end
+        end
+      end
+
+      warn "xip DNS listening on #{host}:#{port} for #{normalize_name(zone)}"
+      [udp_thread, tcp_thread].each(&:join)
+    ensure
+      udp&.close
+      tcp&.close
+    end
+
+    def records_for(name, type, klass, zone:, default_ip:, nameserver:, ttl:)
+      return [] unless klass == CLASS_IN
+
+      normalized_name = normalize_name(name)
+      normalized_zone = normalize_name(zone)
+      return [] unless normalized_name == normalized_zone || normalized_name.end_with?(".#{normalized_zone}")
+
+      case type
+      when TYPE_A
+        ip = normalized_name == normalized_zone ? default_ip : extract_ipv4(normalized_name, normalized_zone)
+        ip ? [resource_record(TYPE_A, ttl, IPAddr.new(ip).hton)] : []
+      when TYPE_NS
+        normalized_name == normalized_zone ? [resource_record(TYPE_NS, ttl, encode_name(nameserver))] : []
+      when TYPE_SOA
+        return [] unless normalized_name == normalized_zone
+
+        soa = encode_name(nameserver) + encode_name("hostmaster.#{normalized_zone}")
+        soa += [Time.now.to_i, 3600, 600, 86_400, ttl].pack('N5')
+        [resource_record(TYPE_SOA, ttl, soa)]
+      else
+        []
+      end
+    end
+
+    def resource_record(type, ttl, data)
+      [0xc00c, type, CLASS_IN, ttl, data.bytesize].pack('nnnNn') + data
+    end
+
+    def relative_labels(name, zone)
+      normalized_name = normalize_name(name)
+      normalized_zone = normalize_name(zone)
+      return [] if normalized_name == normalized_zone
+      return unless normalized_name.end_with?(".#{normalized_zone}")
+
+      normalized_name.delete_suffix(".#{normalized_zone}").split('.')
+    end
+
+    def valid_ipv4?(candidate)
+      IPAddr.new(candidate).ipv4? && candidate.split('.').length == 4
+    rescue IPAddr::InvalidAddressError
+      false
+    end
+
+    def normalize_name(name)
+      name.to_s.downcase.sub(/\.\z/, '')
+    end
+
+    def decode_name(packet, offset)
+      labels = []
+
+      loop do
+        length = packet.getbyte(offset)
+        raise ArgumentError, 'invalid DNS name' if length.nil?
+
+        offset += 1
+        break if length.zero?
+        raise ArgumentError, 'compressed question names are unsupported' unless (length & 0xc0).zero?
+
+        label = packet.byteslice(offset, length)
+        raise ArgumentError, 'truncated DNS name' unless label&.bytesize == length
+
+        labels << label
+        offset += length
+      end
+
+      [labels.join('.'), offset]
+    end
+
+    def encode_name(name)
+      normalize_name(name).split('.').map { |label| [label.bytesize].pack('C') + label }.join + "\0"
+    end
+  end
+end

--- a/myurls.rb
+++ b/myurls.rb
@@ -26,6 +26,16 @@ module Myurls
     end
 
     get '/' do
+      if request.host == ENV.fetch('XIP_WEB_HOST', 'xip.1gb.xyz')
+        @page_title = 'xip.1gb.xyz — IP addresses as hostnames'
+        @site_name = 'XIP.1GB.XYZ'
+        @body_class = 'xip-page'
+        return haml :xip
+      end
+
+      @page_title = '1gb.xyz — Small links, no noise'
+      @site_name = '1GB.XYZ'
+      @body_class = 'myurls-page'
       @url = request.host
       unless request.port == 80 || request.port == 443
         @url += ":#{request.port}"

--- a/public/javascripts/application.js
+++ b/public/javascripts/application.js
@@ -8,6 +8,28 @@ $(function () {
   var clipboard = new ClipboardJS("#copy");
   var linksClipboard = new ClipboardJS(".copy-btn");
 
+  var xipInput = $("#xip-ip");
+  var xipResult = $("#xip-result");
+  var xipStatus = $("#xip-status");
+
+  xipInput.on("input", function () {
+    var ip = xipInput.val().trim();
+    var parts = ip.split(".");
+    var valid =
+      parts.length === 4 &&
+      parts.every(function (part) {
+        return /^\d{1,3}$/.test(part) && Number(part) <= 255;
+      });
+
+    if (valid) {
+      xipResult.text(parts.join("-") + ".xip.1gb.xyz");
+      xipStatus.text("Ready to resolve");
+    } else {
+      xipResult.text("Enter a valid IPv4 address");
+      xipStatus.text("Four octets, each from 0 to 255");
+    }
+  });
+
   var copyTooltip = $("#copy-tooltip");
 
   clipboard.on("success", function () {

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -3,6 +3,438 @@
   visibility: hidden;
 }
 
+.site-nav {
+  position: relative;
+  z-index: 20;
+}
+
+.site-nav-inner {
+  width: min(1180px, calc(100% - 32px));
+  min-height: 72px;
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.site-logo {
+  font: 900 24px/1 ui-monospace, SFMono-Regular, Menlo, monospace;
+  text-decoration: none;
+}
+
+.site-nav-meta {
+  display: flex;
+  align-items: center;
+  gap: 24px;
+  font: 700 11px/1 ui-monospace, SFMono-Regular, Menlo, monospace;
+  letter-spacing: 0.12em;
+}
+
+.site-nav-meta a {
+  text-decoration: underline;
+  text-underline-offset: 4px;
+}
+
+.site-footer {
+  width: min(1180px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 28px 0 36px;
+  display: flex;
+  justify-content: space-between;
+  border-top: 1px solid currentColor;
+  font: 700 11px/1 ui-monospace, SFMono-Regular, Menlo, monospace;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.site-footer a {
+  color: inherit;
+}
+
+.myurls-page {
+  --short-ink: #10251d;
+  --short-paper: #f5eddc;
+  --short-red: #f04d32;
+  --short-lime: #cbea61;
+  min-height: 100vh;
+  color: var(--short-ink);
+  background:
+    linear-gradient(rgba(16, 37, 29, 0.055) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(16, 37, 29, 0.055) 1px, transparent 1px),
+    var(--short-paper);
+  background-size: 32px 32px;
+}
+
+.myurls-page .site-nav {
+  color: var(--short-paper);
+  background: var(--short-ink);
+  border-bottom: 5px solid var(--short-red);
+}
+
+.myurls-page .site-logo {
+  color: var(--short-lime);
+}
+
+.myurls-page .site-nav-meta a {
+  color: white;
+}
+
+.shortener-shell {
+  width: min(1180px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 72px 0 88px;
+}
+
+.shortener-hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  align-items: center;
+  gap: 54px;
+  min-height: 650px;
+}
+
+.shortener-copy {
+  grid-row: 2;
+  display: grid;
+  grid-template-columns: minmax(0, 1.15fr) minmax(320px, 0.85fr);
+  column-gap: 70px;
+  align-items: end;
+}
+
+.shortener-kicker,
+.shortener-copy h1 {
+  grid-column: 1;
+}
+
+.shortener-copy > p {
+  grid-column: 2;
+  grid-row: 1 / span 2;
+  align-self: end;
+  padding-bottom: 10px;
+}
+
+.shortener-kicker {
+  display: inline-block;
+  padding: 7px 10px;
+  color: var(--short-paper);
+  background: var(--short-red);
+  font: 800 11px/1 ui-monospace, SFMono-Regular, Menlo, monospace;
+  letter-spacing: 0.16em;
+}
+
+.shortener-copy h1 {
+  margin: 28px 0 26px;
+  font-family: Georgia, 'Times New Roman', serif;
+  font-size: clamp(62px, 7vw, 98px);
+  font-weight: 700;
+  line-height: 0.88;
+  letter-spacing: -0.07em;
+}
+
+.shortener-copy h1 em {
+  display: block;
+  color: var(--short-red);
+  font-weight: 400;
+}
+
+.shortener-copy > p {
+  max-width: 570px;
+  margin: 0;
+  font-size: 19px;
+  line-height: 1.65;
+}
+
+.shortener-notes {
+  grid-column: 1 / -1;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 9px;
+  margin-top: 34px;
+}
+
+.shortener-notes span {
+  padding: 8px 10px;
+  border: 1px solid var(--short-ink);
+  background: rgba(255, 255, 255, 0.45);
+  font: 700 11px/1 ui-monospace, SFMono-Regular, Menlo, monospace;
+  text-transform: uppercase;
+}
+
+.shortener-stage {
+  position: relative;
+  grid-row: 1;
+  width: 100%;
+}
+
+.shortener-stamp {
+  position: absolute;
+  z-index: 12;
+  top: -32px;
+  right: -24px;
+  width: 88px;
+  height: 88px;
+  display: grid;
+  place-items: center;
+  border-radius: 50%;
+  color: var(--short-ink);
+  background: var(--short-lime);
+  border: 2px solid var(--short-ink);
+  font: 900 13px/1 ui-monospace, SFMono-Regular, Menlo, monospace;
+  transform: rotate(12deg);
+}
+
+#bar.shortener-flipper {
+  width: 100%;
+  height: 300px;
+}
+
+.shortener-panel {
+  width: 100%;
+  min-height: 300px;
+  padding: 40px 48px;
+  color: white;
+  background: var(--short-ink);
+  border: 2px solid var(--short-ink);
+  box-shadow: 16px 16px 0 var(--short-red);
+}
+
+.shortener-panel label,
+.shortener-result-label {
+  display: block;
+  margin-bottom: 13px;
+  color: var(--short-lime);
+  font: 800 11px/1 ui-monospace, SFMono-Regular, Menlo, monospace;
+  letter-spacing: 0.13em;
+  text-transform: uppercase;
+}
+
+.shortener-input-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: stretch;
+}
+
+.shortener-domain,
+.shortener-input-row input,
+.shortener-input-row button {
+  min-height: 72px;
+  border: 0;
+}
+
+.shortener-domain {
+  display: flex;
+  align-items: center;
+  padding: 0 20px;
+  color: var(--short-ink);
+  background: var(--short-lime);
+  font: 800 14px/1 ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+.shortener-input-wrap {
+  min-width: 0;
+}
+
+.shortener-input-row input {
+  width: 100%;
+  padding: 0 22px;
+  color: var(--short-ink);
+  background: white;
+  outline: 0;
+  font-size: 18px;
+}
+
+.shortener-input-row input:focus {
+  box-shadow: inset 0 -4px 0 var(--short-red);
+}
+
+.shortener-input-row button,
+.shortener-result button {
+  padding: 0 28px;
+  color: white;
+  background: var(--short-red);
+  border: 0;
+  font-weight: 900;
+  cursor: pointer;
+}
+
+.shortener-input-row button b {
+  margin-left: 12px;
+  font-size: 20px;
+}
+
+.shortener-input-row button:disabled {
+  cursor: wait;
+  opacity: 0.55;
+}
+
+.shortener-panel .tooltip {
+  left: 12px;
+  top: -36px;
+  padding: 7px 9px;
+  color: white;
+  background: var(--short-red);
+  font: 700 11px/1 ui-monospace, SFMono-Regular, Menlo, monospace;
+  white-space: nowrap;
+}
+
+.shortener-example {
+  margin-top: 32px;
+  padding-top: 20px;
+  border-top: 1px solid rgba(255, 255, 255, 0.24);
+  color: #9aaba3;
+  font: 12px/1.6 ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+.shortener-example span {
+  display: block;
+  margin-bottom: 7px;
+  color: var(--short-red);
+  font-weight: 900;
+}
+
+.shortener-result {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.shortener-result input {
+  width: 100%;
+  min-height: 72px;
+  padding: 17px 22px;
+  border: 0;
+  color: var(--short-ink);
+  background: white;
+  font: 800 19px/1.4 ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+.shortener-result-actions {
+  display: flex;
+  align-items: center;
+  gap: 24px;
+  margin-top: 22px;
+}
+
+.shortener-result button {
+  min-height: 48px;
+}
+
+.shortener-result a {
+  color: var(--short-lime);
+  font-weight: 800;
+}
+
+.shortener-manifesto {
+  display: grid;
+  grid-template-columns: 80px 1.2fr 0.8fr;
+  gap: 30px;
+  align-items: start;
+  margin-top: 70px;
+  padding: 38px 0 0;
+  border-top: 3px solid var(--short-ink);
+}
+
+.manifesto-number {
+  font: 900 34px/1 ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+.shortener-manifesto h2 {
+  margin: 0;
+  font: 700 38px/1.05 Georgia, 'Times New Roman', serif;
+}
+
+.shortener-manifesto p {
+  margin: 0 0 20px;
+  line-height: 1.65;
+}
+
+.shortener-manifesto a {
+  grid-column: 3;
+  color: var(--short-red);
+  font-weight: 900;
+}
+
+@media (max-width: 920px) {
+  .shortener-hero {
+    grid-template-columns: 1fr;
+    gap: 70px;
+  }
+
+  .shortener-copy {
+    display: block;
+    max-width: 720px;
+  }
+
+  .shortener-manifesto {
+    grid-template-columns: 60px 1fr;
+  }
+
+  .shortener-manifesto p,
+  .shortener-manifesto a {
+    grid-column: 2;
+  }
+}
+
+@media (max-width: 620px) {
+  .site-nav-meta span {
+    display: none;
+  }
+
+  .shortener-shell {
+    padding-top: 48px;
+  }
+
+  .shortener-copy h1 {
+    font-size: 58px;
+  }
+
+  .shortener-stage {
+    margin-right: 8px;
+  }
+
+  #bar.shortener-flipper,
+  .shortener-panel {
+    min-height: 470px;
+    height: 470px;
+  }
+
+  .shortener-panel {
+    padding: 28px 22px;
+    box-shadow: 8px 8px 0 var(--short-red);
+  }
+
+  .shortener-input-row {
+    grid-template-columns: 1fr;
+  }
+
+  .shortener-domain {
+    min-height: 40px;
+  }
+
+  .shortener-input-row button {
+    margin-top: 8px;
+  }
+
+  .shortener-result-actions {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .shortener-manifesto {
+    grid-template-columns: 1fr;
+  }
+
+  .shortener-manifesto p,
+  .shortener-manifesto a {
+    grid-column: 1;
+  }
+
+  .site-footer {
+    gap: 18px;
+    flex-direction: column;
+  }
+}
+
 .tooltip::before {
   bottom: -5px;
   left: 50%;
@@ -26,6 +458,7 @@
 }
 
 #bar {
+  position: relative;
   -webkit-transform-style: preserve-3d;
   transform-style: preserve-3d;
   -webkit-transition-duration: 0.8s;
@@ -37,6 +470,7 @@
 }
 
 #bar .side {
+  position: absolute;
   -webkit-backface-visibility: hidden;
   backface-visibility: hidden;
   left: 0;
@@ -64,4 +498,255 @@
   -webkit-transform: rotateX(180deg);
   transform: rotateX(180deg);
   z-index: 0;
+}
+
+.xip-page {
+  --ink: #17211b;
+  --acid: #d9ff43;
+  --paper: #f4f1e8;
+  --orange: #ff6b35;
+  color: var(--ink);
+  background:
+    radial-gradient(circle at 88% 12%, rgba(255, 107, 53, 0.28), transparent 28rem),
+    linear-gradient(135deg, rgba(23, 33, 27, 0.055) 25%, transparent 25%) 0 0 / 18px 18px,
+    var(--paper);
+  min-height: 100vh;
+}
+
+.xip-page nav {
+  background: var(--ink);
+  border-bottom: 4px solid var(--acid);
+}
+
+.xip-page nav a {
+  color: var(--acid);
+  letter-spacing: 0.08em;
+}
+
+.xip-shell {
+  width: min(1180px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 72px 0 96px;
+}
+
+.xip-hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1.15fr) minmax(320px, 0.85fr);
+  gap: 56px;
+  align-items: end;
+}
+
+.xip-kicker,
+.xip-card-number {
+  display: inline-block;
+  padding: 6px 10px;
+  background: var(--ink);
+  color: var(--acid);
+  font: 700 12px/1 ui-monospace, SFMono-Regular, Menlo, monospace;
+  letter-spacing: 0.14em;
+}
+
+.xip-hero h1 {
+  grid-column: 1;
+  margin: 24px 0 20px;
+  font-family: Georgia, 'Times New Roman', serif;
+  font-size: clamp(56px, 8vw, 112px);
+  line-height: 0.84;
+  letter-spacing: -0.065em;
+}
+
+.xip-hero h1 span {
+  color: var(--orange);
+}
+
+.xip-intro {
+  grid-column: 1;
+  max-width: 680px;
+  margin: 0;
+  font-size: 19px;
+  line-height: 1.65;
+}
+
+.xip-builder {
+  grid-column: 2;
+  grid-row: 1 / span 3;
+  padding: 30px;
+  background: var(--ink);
+  color: white;
+  box-shadow: 14px 14px 0 var(--orange);
+  transform: rotate(1deg);
+}
+
+.xip-builder label {
+  display: block;
+  margin-bottom: 12px;
+  color: var(--acid);
+  font: 700 13px/1 ui-monospace, SFMono-Regular, Menlo, monospace;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+
+.xip-builder-row {
+  display: flex;
+}
+
+.xip-builder input,
+.xip-builder button {
+  min-height: 52px;
+  border: 0;
+}
+
+.xip-builder input {
+  min-width: 0;
+  flex: 1;
+  padding: 0 16px;
+  color: var(--ink);
+  background: white;
+  font: 700 16px/1 ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+.xip-builder button {
+  padding: 0 18px;
+  background: var(--acid);
+  color: var(--ink);
+  font-weight: 800;
+  cursor: pointer;
+}
+
+.xip-builder code {
+  display: block;
+  margin-top: 22px;
+  overflow-wrap: anywhere;
+  color: white;
+  font: 700 18px/1.45 ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+.xip-status {
+  display: block;
+  margin-top: 8px;
+  color: #aab4ad;
+  font-size: 13px;
+}
+
+.xip-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 18px;
+  margin-top: 92px;
+}
+
+.xip-card {
+  min-height: 260px;
+  padding: 28px;
+  border: 2px solid var(--ink);
+  background: rgba(255, 255, 255, 0.62);
+}
+
+.xip-card:nth-child(2) {
+  background: var(--acid);
+}
+
+.xip-card h2 {
+  margin: 44px 0 14px;
+  font: 700 28px/1.1 Georgia, 'Times New Roman', serif;
+}
+
+.xip-card code {
+  font: 700 14px/1.5 ui-monospace, SFMono-Regular, Menlo, monospace;
+  overflow-wrap: anywhere;
+}
+
+.xip-card p {
+  margin: 16px 0 0;
+  line-height: 1.6;
+}
+
+.xip-command {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 28px;
+  margin-top: 18px;
+  padding: 30px;
+  background: var(--orange);
+  border: 2px solid var(--ink);
+}
+
+.xip-command span,
+.xip-command strong {
+  display: block;
+}
+
+.xip-command span {
+  font: 700 12px/1 ui-monospace, SFMono-Regular, Menlo, monospace;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.xip-command strong {
+  margin-top: 8px;
+  font: 700 25px/1 Georgia, 'Times New Roman', serif;
+}
+
+.xip-command code {
+  padding: 14px 18px;
+  background: var(--ink);
+  color: white;
+  font: 700 14px/1.4 ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+@media (max-width: 850px) {
+  .xip-shell {
+    padding-top: 48px;
+  }
+
+  .xip-hero {
+    grid-template-columns: 1fr;
+    gap: 34px;
+  }
+
+  .xip-hero h1,
+  .xip-intro,
+  .xip-builder {
+    grid-column: 1;
+    grid-row: auto;
+  }
+
+  .xip-builder {
+    transform: none;
+    box-shadow: 8px 8px 0 var(--orange);
+  }
+
+  .xip-grid {
+    grid-template-columns: 1fr;
+    margin-top: 64px;
+  }
+
+  .xip-command {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+}
+
+@media (max-width: 520px) {
+  .xip-hero h1 {
+    font-size: 52px;
+  }
+
+  .xip-builder {
+    padding: 22px;
+  }
+
+  .xip-builder-row {
+    flex-direction: column;
+  }
+
+  .xip-builder button {
+    margin-top: 8px;
+  }
+
+  .xip-command code {
+    width: 100%;
+    overflow-wrap: anywhere;
+  }
 }

--- a/test/myurls_test.rb
+++ b/test/myurls_test.rb
@@ -12,4 +12,13 @@ class MyurlsTest < Minitest::Test
     assert last_response.ok?
     assert_includes last_response.body, 'myurls'
   end
+
+  def test_xip_host_renders_xip_page
+    header 'Host', 'xip.1gb.xyz'
+    get '/'
+
+    assert last_response.ok?
+    assert_includes last_response.body, '127-0-0-1.xip.1gb.xyz'
+    assert_includes last_response.body, 'Put an IP address'
+  end
 end

--- a/test/xip_dns_test.rb
+++ b/test/xip_dns_test.rb
@@ -1,0 +1,50 @@
+require 'test_helper'
+
+class XipDnsTest < Minitest::Test
+  ZONE = 'xip.1gb.xyz'
+
+  def test_extracts_dotted_ipv4
+    assert_equal '127.0.0.1', Myurls::XipDns.extract_ipv4('127.0.0.1.xip.1gb.xyz', ZONE)
+    assert_equal '10.20.30.40', Myurls::XipDns.extract_ipv4('app.10.20.30.40.xip.1gb.xyz', ZONE)
+  end
+
+  def test_extracts_dashed_ipv4
+    assert_equal '127.0.0.1', Myurls::XipDns.extract_ipv4('127-0-0-1.xip.1gb.xyz', ZONE)
+    assert_equal '192.168.1.20', Myurls::XipDns.extract_ipv4('app.192-168-1-20.xip.1gb.xyz', ZONE)
+  end
+
+  def test_rejects_invalid_or_unrelated_names
+    assert_nil Myurls::XipDns.extract_ipv4('999-0-0-1.xip.1gb.xyz', ZONE)
+    assert_nil Myurls::XipDns.extract_ipv4('127-0-0-1.example.com', ZONE)
+  end
+
+  def test_builds_a_response
+    response = Myurls::XipDns.answer(
+      query('127-0-0-1.xip.1gb.xyz'),
+      zone: ZONE,
+      default_ip: '119.28.176.85',
+      nameserver: '1gb.xyz'
+    )
+
+    assert_equal 1, response.byteslice(6, 2).unpack1('n')
+    assert_equal IPAddr.new('127.0.0.1').hton, response.byteslice(-4, 4)
+  end
+
+  def test_zone_apex_uses_default_ip
+    response = Myurls::XipDns.answer(
+      query(ZONE),
+      zone: ZONE,
+      default_ip: '119.28.176.85',
+      nameserver: '1gb.xyz'
+    )
+
+    assert_equal IPAddr.new('119.28.176.85').hton, response.byteslice(-4, 4)
+  end
+
+  private
+
+  def query(name, type = Myurls::XipDns::TYPE_A)
+    header = [1234, 0x0100, 1, 0, 0, 0].pack('n6')
+    header + Myurls::XipDns.encode_name(name) + [type, Myurls::XipDns::CLASS_IN].pack('n2')
+  end
+end

--- a/views/footer.haml
+++ b/views/footer.haml
@@ -1,5 +1,3 @@
-%footer
-  .w-full.mx-auto.fixed.bottom-0
-    .border-t.border-gray-200.pt-4.mb-4
-      %p.text-base.text-gray-400.text-center
-        %a{:href => "https://github.com/fatjyc/myurls"} https://github.com/fatjyc/myurls
+%footer.site-footer
+  %span Built small on purpose.
+  %a{:href => "https://github.com/fatjyc/myurls"} Source on GitHub ↗

--- a/views/header.haml
+++ b/views/header.haml
@@ -1,6 +1,10 @@
-%nav.bg-gray-800
-  .max-w-7xl.mx-auto.px-2.sm:px-6.lg:px-8
-    .relative.flex.items-center.justify-between.h-16
-      .flex-1.flex.items-center.justify-center.sm:items-stretch.sm:justify-start
-        .flex-shrink-0.flex.items-center
-          %a.text-gray-300.hover:text-white.uppercase.text-2xl.font-sans.font-bold{href: "/"} MYURLS
+%nav.site-nav
+  .site-nav-inner
+    %a.site-logo{href: "/"}= @site_name || 'MYURLS'
+    - if @body_class == 'myurls-page'
+      .site-nav-meta
+        %span 1 GB OF INTERNET
+    - elsif @body_class == 'xip-page'
+      .site-nav-meta
+        %span DYNAMIC DNS
+        %a{href: "https://1gb.xyz"} Short links

--- a/views/layout.haml
+++ b/views/layout.haml
@@ -6,12 +6,12 @@
     %meta{:content => "width=device-width, initial-scale=1", :name => "viewport"}/
     %link{:href => "/favicon.ico", :rel => "icon", :type => "image/x-icon"}/
     %link{:href => "/stylesheets/lib/tailwind.min.css", :rel => "stylesheet"}/
-    %link{:href => "/stylesheets/main.css", :rel => "stylesheet"}/
-    %title Myurls
-  %body.font-sans.antialiased
+    %link{:href => "/stylesheets/main.css?v=20260717-3", :rel => "stylesheet"}/
+    %title= @page_title || 'Myurls'
+  %body.font-sans.antialiased{:class => @body_class}
     = haml :header
     = yield
     = haml :footer
     %script{:src => "/javascripts/lib/jquery-3.4.1.min.js"}
     %script{:src => "/javascripts/lib/clipboard.min.js"}
-    %script{:src => "/javascripts/application.js"}
+    %script{:src => "/javascripts/application.js?v=20260717-3"}

--- a/views/url.haml
+++ b/views/url.haml
@@ -1,21 +1,51 @@
-.mt-40
-  %div#bar{class: "relative mx-auto w-4/5"}
-    #front.side.absolute.w-full.p-10.bg-white.rounded-md.shadow-xl
-      %form.flex.rounded-md{:action => "/url", :method => "post"}
-        %span.items-center.px-3.rounded-l-md.border.border-r-0.border-gray-300.bg-gray-50.text-gray-500.text-sm.hidden.sm:inline-flex
-          = @url
-        .has-tooltip.flex-1.min-w-0.w-full
-          %span#input-tooltip.tooltip.text-xs.text-white.bg-black.rounded-sm.px-2.py-1.-top-8{class: "left-1/2"} Invalid url
-          %input#url.border.border-gray-300.flex-1.min-w-0.block.w-full.px-3.py-2.rounded-l-md.sm:rounded-none.focus:outline-none.focus:ring-indigo-500.focus:border-indigo-500.text-sm.border-gray-300{name: "url", placeholder: "URL", type: "text"}/
-        %button#start.relative.inline-flex.items-center.space-x-2.px-4.py-2.border.border-gray-300.border-l-0.text-sm.font-medium.rounded-r-md.text-gray-700.bg-gray-50.hover:bg-gray-100.disabled:bg-gray-400{:type => "submit"}
-          Shorten
+%main.shortener-shell
+  %section.shortener-hero
+    .shortener-copy
+      .shortener-kicker SHORT LINKS / LONG LIFE
+      %h1
+        Make the web
+        %em pocket-sized.
+      %p
+        Paste a long URL. Get a tiny one on
+        %strong 1gb.xyz.
+        No accounts, dashboards, or unnecessary ceremony.
 
-    #back.side.absolute.w-full.p-10.bg-white.rounded-md.shadow-xl.flex
-      %span.items-center.px-3.rounded-l-md.border.border-r-0.border-gray-300.bg-gray-50.text-gray-500.text-sm.hidden.sm:inline-flex
-        = @url
-      %input#s-url.border.border-gray-300.flex-1.min-w-0.w-full.px-3.py-2.rounded-l-md.sm:rounded-none.focus:outline-none.focus:ring-indigo-500.focus:border-indigo-500.text-sm.border-gray-300{name: "url", placeholder: "URL", type: "text", :readonly => "readonly"}/
-      .has-tooltip
-        %span#copy-tooltip.tooltip.text-xs.text-white.bg-black.rounded-sm.px-2.py-1.-top-8.left-1 copied
-        %button#copy.relative.inline-flex.items-center.space-x-2.px-4.py-2.border.border-gray-300.border-l-0.text-sm.font-medium.rounded-r-md.text-gray-700.bg-gray-50.hover:bg-gray-100{"data-clipboard-target" => "#s-url"}
-          Copy
-      %a#restart.ml-8.text-blue-500.hover:text-blue-400{:style => "height: 38px; line-height: 38px;",:href => "javascript:void(0)"} Shorten another URL
+      .shortener-notes
+        %span 7-character links
+        %span Instant redirects
+        %span Made in 2019
+
+    .shortener-stage
+      .shortener-stamp 001 GB
+      #bar.shortener-flipper
+        #front.side.shortener-panel
+          %form{:action => "/url", :method => "post"}
+            %label{:for => "url"} Your extremely long URL
+            .shortener-input-row
+              .shortener-domain= @url
+              .has-tooltip.shortener-input-wrap
+                %span#input-tooltip.tooltip Invalid URL — include https://
+                %input#url{name: "url", placeholder: "https://example.com/a/very/long/path", type: "url", autocomplete: "url"}/
+              %button#start{:type => "submit"}
+                %span Shrink it
+                %b ↘
+          .shortener-example
+            %span BEFORE
+            %del https://the-internet.example.com/needlessly/long/address
+
+        #back.side.shortener-panel.shortener-result
+          %div
+            %span.shortener-result-label YOUR SMALLER INTERNET
+            %input#s-url{name: "url", type: "text", :readonly => "readonly"}/
+          .shortener-result-actions
+            .has-tooltip
+              %span#copy-tooltip.tooltip Copied
+              %button#copy{"data-clipboard-target" => "#s-url"} Copy link
+            %a#restart{:href => "javascript:void(0)"} Shorten another ↻
+
+  %section.shortener-manifesto
+    .manifesto-number 01
+    %h2 The useful part of a URL, without the luggage.
+    %p
+      Short links are easier to type, print, share, and remember. This service does one job and stays out of the way.
+    %a{href: "https://xip.1gb.xyz"} Need an IP-based hostname? Try xip.1gb.xyz →

--- a/views/xip.haml
+++ b/views/xip.haml
@@ -1,0 +1,40 @@
+%main.xip-shell
+  %section.xip-hero
+    .xip-kicker DNS FOR HUMANS
+    %h1
+      Put an IP address
+      %br/
+      %span inside a hostname.
+    %p.xip-intro
+      No hosts file. No local DNS setup. Use dotted or dashed IPv4 addresses for local development, callbacks, certificates, and quick device testing.
+
+    .xip-builder
+      %label{:for => "xip-ip"} Try an IPv4 address
+      .xip-builder-row
+        %input#xip-ip{:type => "text", :value => "127.0.0.1", :inputmode => "decimal", :autocomplete => "off", :spellcheck => "false"}/
+        %button#xip-copy.copy-btn{"data-clipboard-target" => "#xip-result", :type => "button"} Copy hostname
+      %code#xip-result 127-0-0-1.xip.1gb.xyz
+      %span#xip-status.xip-status Ready to resolve
+
+  %section.xip-grid
+    %article.xip-card
+      %span.xip-card-number 01
+      %h2 Dotted format
+      %code 192.168.1.20.xip.1gb.xyz
+      %p Reads naturally and resolves directly to 192.168.1.20.
+    %article.xip-card
+      %span.xip-card-number 02
+      %h2 Dashed format
+      %code 192-168-1-20.xip.1gb.xyz
+      %p Safer in tools that treat dots as hostname boundaries.
+    %article.xip-card
+      %span.xip-card-number 03
+      %h2 Add a prefix
+      %code app.10-0-0-8.xip.1gb.xyz
+      %p Name services while keeping the embedded address discoverable.
+
+  %section.xip-command
+    %div
+      %span Verify it
+      %strong One command, one answer.
+    %code dig 127-0-0-1.xip.1gb.xyz A +short


### PR DESCRIPTION
## What changed

- integrate an authoritative xip-style DNS server into the Myurls image
- support dotted and dashed IPv4 hostnames, including optional service prefixes
- add a dedicated `xip` documentation page and refresh the `1gb.xyz` shortener UI
- make the DNS service optional through a Docker Compose profile
- add configurable deployment settings through `.env.example`
- replace the destructive database initializer with safe migrations
- expand the README with Docker, Nginx, HTTPS, DNS delegation, backup, and troubleshooting instructions

## Why

The deployment previously depended on a separate, old `xip.name` image, only supported dotted IP hostnames, and had sparse deployment documentation. The database initializer also removed the production database before migrating.

This change keeps the URL shortener and dynamic DNS functionality in one maintained project while making a fresh deployment easier and safer.

## Impact

- existing URL shortening and redirect behavior remains unchanged
- xip DNS is opt-in with `docker compose --profile xip`
- both `127.0.0.1.xip.example.com` and `127-0-0-1.xip.example.com` resolve correctly
- production database migrations no longer delete existing data
- static assets use versioned URLs to avoid stale browser caches after deployment

## Validation

- `docker compose config --quiet`
- `docker compose --profile xip config --quiet`
- `bash -n init_db.sh`
- `git diff --check`
- `bundle exec rake test` in the production Ruby container: 8 tests, 18 assertions, 0 failures
- live UDP and TCP DNS queries for dotted and dashed hostname formats
- live browser verification of the refreshed shortener page
