### PR TITLE
[codex] Align production supervision and HTTPS config

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,34 @@ docker compose restart myurls
 docker compose --profile xip down
 ```
 
+### Run web and DNS in one container
+
+The default Compose file keeps web and DNS as separate services so either can
+be upgraded or restarted independently. On a small server they can share one
+container through the included supervisor:
+
+```yaml
+services:
+  myurls:
+    command: bundle exec ruby bin/myurls-server
+    environment:
+      - APP_ENV=production
+      - RACK_ENV=production
+      - ENABLE_XIP_DNS=true
+      - DNS_PORT=8053
+      - DNS_ZONE=xip.example.com
+      - DNS_DEFAULT_IP=203.0.113.10
+      - DNS_NAMESERVER=short.example.com
+    ports:
+      - "127.0.0.1:9292:9292"
+      - "53:8053/tcp"
+      - "53:8053/udp"
+```
+
+The supervisor forwards termination signals and stops the container if either
+Unicorn or the DNS process exits unexpectedly, allowing the restart policy to
+recover both services.
+
 ## Tests
 
 Run the test suite inside the production Ruby environment:

--- a/bin/myurls-server
+++ b/bin/myurls-server
@@ -1,0 +1,48 @@
+#!/usr/bin/env ruby
+# encoding: UTF-8
+
+children = {}
+stopping = false
+
+commands = {
+  'web' => %w[bundle exec unicorn -c config/unicorn.rb]
+}
+
+if ENV.fetch('ENABLE_XIP_DNS', 'false') == 'true'
+  commands['dns'] = %w[bundle exec ruby bin/xip-dns]
+end
+
+terminate = lambda do |signal|
+  children.each_value do |pid|
+    Process.kill(signal, -pid)
+  rescue Errno::ESRCH
+    nil
+  end
+end
+
+Signal.trap('TERM') do
+  stopping = true
+  terminate.call('TERM')
+end
+Signal.trap('INT') do
+  stopping = true
+  terminate.call('INT')
+end
+
+commands.each do |name, command|
+  pid = Process.spawn(*command, pgroup: true)
+  children[name] = pid
+  warn "started #{name} process pid=#{pid}"
+end
+
+finished_pid, status = Process.wait2
+finished_name = children.key(finished_pid) || finished_pid.to_s
+children.delete(finished_name)
+
+unless stopping
+  warn "#{finished_name} process exited unexpectedly (#{status.inspect}); stopping container"
+  terminate.call('TERM')
+end
+
+Process.waitall
+exit(stopping ? 0 : (status.exitstatus || 1))

--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -2,7 +2,7 @@
 # note the trailing slash in this example
 @dir = File.expand_path('../../', __FILE__)
 
-worker_processes 2
+worker_processes Integer(ENV.fetch('WEB_CONCURRENCY', '2'))
 working_directory @dir
 
 timeout 30

--- a/deploy/nginx/1gb.xyz.conf
+++ b/deploy/nginx/1gb.xyz.conf
@@ -1,0 +1,42 @@
+server {
+    listen 80;
+    listen [::]:80;
+    server_name 1gb.xyz www.1gb.xyz;
+
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+    }
+
+    location / {
+        return 301 https://1gb.xyz$request_uri;
+    }
+}
+
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+    server_name 1gb.xyz;
+
+    ssl_certificate /etc/letsencrypt/live/1gb.xyz/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/1gb.xyz/privkey.pem;
+    include /etc/letsencrypt/options-ssl-nginx.conf;
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+
+    location / {
+        include proxy.conf;
+        proxy_pass http://127.0.0.1:9292;
+    }
+}
+
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+    server_name www.1gb.xyz;
+
+    ssl_certificate /etc/letsencrypt/live/1gb.xyz/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/1gb.xyz/privkey.pem;
+    include /etc/letsencrypt/options-ssl-nginx.conf;
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+
+    return 301 https://1gb.xyz$request_uri;
+}

--- a/deploy/nginx/xip.1gb.xyz.conf
+++ b/deploy/nginx/xip.1gb.xyz.conf
@@ -3,6 +3,19 @@ server {
     listen [::]:80;
     server_name xip.1gb.xyz;
 
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+    server_name xip.1gb.xyz;
+
+    ssl_certificate /etc/letsencrypt/live/xip.1gb.xyz/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/xip.1gb.xyz/privkey.pem;
+    include /etc/letsencrypt/options-ssl-nginx.conf;
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+
     location / {
         include proxy.conf;
         proxy_pass http://127.0.0.1:9292;

--- a/deploy/nginx/xip.1gb.xyz.conf
+++ b/deploy/nginx/xip.1gb.xyz.conf
@@ -3,7 +3,13 @@ server {
     listen [::]:80;
     server_name xip.1gb.xyz;
 
-    return 301 https://$host$request_uri;
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+    }
+
+    location / {
+        return 301 https://$host$request_uri;
+    }
 }
 
 server {

--- a/lib/xip_dns.rb
+++ b/lib/xip_dns.rb
@@ -61,6 +61,8 @@ module Myurls
           response = answer(packet, zone: zone, default_ip: default_ip, nameserver: nameserver, ttl: ttl)
           udp.send(response, 0, sender[3], sender[1]) if response
         end
+      rescue IOError, Errno::EBADF
+        nil
       end
 
       tcp_thread = Thread.new do
@@ -77,6 +79,8 @@ module Myurls
             connection.close
           end
         end
+      rescue IOError, Errno::EBADF
+        nil
       end
 
       warn "xip DNS listening on #{host}:#{port} for #{normalize_name(zone)}"


### PR DESCRIPTION
## What changed

- add a supervised single-container mode for the Myurls web and xip DNS processes
- make Unicorn worker count configurable for small servers
- add HTTPS virtual hosts for `1gb.xyz`, `www.1gb.xyz`, and `xip.1gb.xyz`
- expose ACME Webroot challenge paths for containerized certificate renewal
- suppress harmless DNS socket-close errors during graceful shutdown

## Why

These changes were deployed while stabilizing the production server after the original PR was merged. They are required to keep the repository aligned with the working production configuration.

## Validation

- 8 tests, 18 assertions, 0 failures
- combined web and DNS container restart test
- HTTPS verification for `1gb.xyz`, `www.1gb.xyz`, and `xip.1gb.xyz`
- dotted and dashed xip DNS queries
- Certbot Webroot challenge and renewal checks
